### PR TITLE
Improve display of long experiment names

### DIFF
--- a/SecuML/web/static/js/dataset_menu.js
+++ b/SecuML/web/static/js/dataset_menu.js
@@ -29,11 +29,8 @@ $.getJSON(query,
                   var name = exp[1];
                   var li = document.createElement('a');
                   li.setAttribute('class', 'list-group-item');
-                  li.setAttribute('style', 'word-wrap: break-word')
+                  li.setAttribute('style', 'word-wrap: break-word');
                   var exp_name = name;
-                  if (exp_name.length > 150) {
-                      exp_name = exp_name.substring(0, 150) + '...';
-                  }
                   exp_name = id + ', ' + exp_name;
                   var e_text = document.createTextNode(exp_name);
                   li.appendChild(e_text);

--- a/SecuML/web/static/js/dataset_menu.js
+++ b/SecuML/web/static/js/dataset_menu.js
@@ -29,6 +29,7 @@ $.getJSON(query,
                   var name = exp[1];
                   var li = document.createElement('a');
                   li.setAttribute('class', 'list-group-item');
+                  li.setAttribute('style', 'word-wrap: break-word')
                   var exp_name = name;
                   if (exp_name.length > 150) {
                       exp_name = exp_name.substring(0, 150) + '...';


### PR DESCRIPTION
Hello
I found that text overflows when experiment name become very long.
![screen shot 2018-08-07 at 12 46 33](https://user-images.githubusercontent.com/1720209/43753416-a29f6368-9a40-11e8-8aa3-5b6223998695.png)

I added word break style to avoid it. Please look on.
