### PR TITLE
Fix feature loading using zip instead of enumerate

### DIFF
--- a/SecuML/exp/data/LoadFeatures.py
+++ b/SecuML/exp/data/LoadFeatures.py
@@ -182,9 +182,9 @@ class LoadFeatures(object):
             names = ids
             descriptions = ids
         # Add features to the DB
-        for i, id in enumerate(ids):
+        for id, name, description in zip(ids, names, descriptions):
             feature = FeaturesAlchemy(user_id=id, file_id=file_id,
-                                  dataset_features_id=self.dataset_features_id,
-                                  name=names[i], description=descriptions[i])
+                                      dataset_features_id=self.dataset_features_id,
+                                      name=name, description=description)
             self.session.add(feature)
         self.session.flush()


### PR DESCRIPTION
Feature loading function `_load_features` of `LoadFeatures` class instanciates `FeaturesAlchemy` objects by iterating over `ids` found in features_description.csv file of the specified dataset. To do so, it uses the enumerate builtin and use the returned indexes to select the right feature's name and description from `names` and `descriptions` arrays.

This can cause error since `names` and `descriptions` are most of the time panda's dataframes and should be accessed using `ids` values and not 0,1,2,3,4 etc.

In my case, my features's ids are starting from 1. This produce a key error like exception on key "0".

This PR change this behavior to use the zip builtin in order to iterate at the same time over the three iterables `ids,`,`descriptions` and `names`.